### PR TITLE
feat(Go): Replace ModelCapabilities with ModelInfo and ModelInfoSupports

### DIFF
--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Package genkit provides Genkit functionality for application developers.
 package genkit
 
@@ -157,7 +156,7 @@ func (g *Genkit) Start(ctx context.Context, opts *StartOptions) error {
 func DefineModel(
 	g *Genkit,
 	provider, name string,
-	metadata *ai.ModelMetadata,
+	metadata *ai.ModelInfo,
 	generate func(context.Context, *ai.ModelRequest, ai.ModelStreamingCallback) (*ai.ModelResponse, error),
 ) ai.Model {
 	return ai.DefineModel(g.reg, provider, name, metadata, generate)

--- a/go/internal/doc-snippets/modelplugin/modelplugin.go
+++ b/go/internal/doc-snippets/modelplugin/modelplugin.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 package modelplugin
 
 import (
@@ -32,14 +31,16 @@ func Init() error {
 	// [START definemodel]
 	genkit.DefineModel(g,
 		providerID, "my-model",
-		&ai.ModelMetadata{
+		&ai.ModelInfo{
 			Label: "my-model",
-			Supports: ai.ModelCapabilities{
+			Supports: &ai.ModelInfoSupports{
+				Context:    false, // Default value set formally
 				Multiturn:  true,  // Does the model support multi-turn chats?
 				SystemRole: true,  // Does the model support syatem messages?
 				Media:      false, // Can the model accept media input?
 				Tools:      false, // Does the model support function calling (tools)?
 			},
+			Versions: make([]string, 0),
 		},
 		func(ctx context.Context,
 			genRequest *ai.ModelRequest,

--- a/go/internal/doc-snippets/ollama.go
+++ b/go/internal/doc-snippets/ollama.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 package snippets
 
 import (
@@ -35,7 +34,7 @@ func ollamaEx(ctx context.Context) error {
 			Name: "gemma2",
 			Type: "chat", // "chat" or "generate"
 		},
-		&ai.ModelCapabilities{
+		&ai.ModelInfoSupports{
 			Multiturn:  true,
 			SystemRole: true,
 			Tools:      false,

--- a/go/plugins/internal/gemini/gemini.go
+++ b/go/plugins/internal/gemini/gemini.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 // Package gemini contains code that is common to both the googleai and vertexai plugins.
 // Most most cannot be shared in this way because the import paths are different.
 package gemini
@@ -10,7 +9,8 @@ import "github.com/firebase/genkit/go/ai"
 
 var (
 	// BasicText describes model capabilities for text-only Gemini models.
-	BasicText = ai.ModelCapabilities{
+	BasicText = ai.ModelInfoSupports{
+		Context:    false, // Default value set formally
 		Multiturn:  true,
 		Tools:      true,
 		SystemRole: true,
@@ -18,7 +18,8 @@ var (
 	}
 
 	//  Multimodal describes model capabilities for multimodal Gemini models.
-	Multimodal = ai.ModelCapabilities{
+	Multimodal = ai.ModelInfoSupports{
+		Context:    false, // Default value set formally
 		Multiturn:  true,
 		Tools:      true,
 		SystemRole: true,

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 package ollama
 
 import (
@@ -38,25 +37,27 @@ var state struct {
 	serverAddress string
 }
 
-func DefineModel(g *genkit.Genkit, model ModelDefinition, caps *ai.ModelCapabilities) ai.Model {
+func DefineModel(g *genkit.Genkit, model ModelDefinition, caps *ai.ModelInfoSupports) ai.Model {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
 		panic("ollama.Init not called")
 	}
-	var mc ai.ModelCapabilities
+	var mc *ai.ModelInfoSupports
 	if caps != nil {
-		mc = *caps
+		mc = caps
 	} else {
-		mc = ai.ModelCapabilities{
+		mc = &ai.ModelInfoSupports{
+			Context:    false, // Default value set formally
 			Multiturn:  true,
 			SystemRole: true,
 			Media:      slices.Contains(mediaSupportedModels, model.Name),
 		}
 	}
-	meta := &ai.ModelMetadata{
+	meta := &ai.ModelInfo{
 		Label:    "Ollama - " + model.Name,
 		Supports: mc,
+		Versions: make([]string, 0),
 	}
 	gen := &generator{model: model, serverAddress: state.serverAddress}
 	return genkit.DefineModel(g, provider, model.Name, meta, gen.generate)


### PR DESCRIPTION
I replaced the model ModelCapabilities and ModelMetadata in order to use ModelInfoSupports and ModelInfo
